### PR TITLE
Add Sway window manager support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,12 @@ That's it! The service is now running and will persist across restarts.
 
 ## 🛠️ Requirements
 
-- Wayland session (Hyprland/Sway)
+- Wayland session
 - Ruby (installed automatically)
 - wl-clipboard (installed automatically)
 
-**Note:** Without Hyprland/Sway, images are still saved but format switching is disabled
+**Full support (auto-switching):** Hyprland, Sway  
+**Partial support (save only):** Any other Wayland compositor
 
 ## 📌 Usage
 
@@ -116,8 +117,8 @@ systemctl --user status clipboard-manager
 # Check Wayland
 echo $XDG_SESSION_TYPE  # Should be "wayland"
 
-# Check Hyprland
-hyprctl version
+# Check compositor (Hyprland or Sway)
+hyprctl version 2>/dev/null || swaymsg -v
 
 # Test clipboard
 echo test | wl-copy && wl-paste


### PR DESCRIPTION
## Summary
- Adds full support for the Sway window manager alongside existing Hyprland support
- Enables automatic format switching (image/path) for Sway users
- Updates documentation to clarify platform support levels

## Changes
- Detect Sway compositor using `swaymsg` command
- Implement window detection via Sway's IPC tree structure
- Parse focused window from Sway's JSON tree recursively
- Update README to distinguish between full support (Hyprland/Sway) and partial support (other Wayland compositors)

## Test Plan
- [ ] Test on Hyprland to ensure no regression
- [ ] Test on Sway to verify window detection works
- [ ] Verify terminal detection works correctly on Sway
- [ ] Confirm image/path switching functions as expected

🤖 Generated with [Claude Code](https://claude.ai/code)